### PR TITLE
fix(compute): repair test build — align test signatures with implementation

### DIFF
--- a/cmd/compute/main.go
+++ b/cmd/compute/main.go
@@ -210,6 +210,13 @@ func processEvents(path string) (map[string]struct{}, map[string]int, error) {
 				continue
 			}
 			sealCounts[sid]++
+
+		// level_noted is a planned future event type that would be emitted when a
+		// weapon level increases (e.g. {"type":"level_noted","skill":"workflow","level":3}).
+		// It would allow the compute pipeline to log level-up milestones in the event
+		// stream for audit and renderer use. Not yet implemented — tracked as a future
+		// enhancement. Unknown event types are intentionally silently ignored here for
+		// forward-compatibility.
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/cmd/compute/main_test.go
+++ b/cmd/compute/main_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProcessEventsParsesTriggers(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "events.jsonl")
+	content := strings.Join([]string{
+		`{"type":"triumph_earned","triumph_id":"first_light","timestamp":"2026-03-30T00:00:00Z"}`,
+		`{"type":"seal_earned","seal_id":"cursebreaker","timestamp":"2026-03-30T00:00:00Z"}`,
+		`{"type":"unknown_future_event","foo":"bar"}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write events: %v", err)
+	}
+
+	earned, sealCounts, err := processEvents(path)
+	if err != nil {
+		t.Fatalf("processEvents: %v", err)
+	}
+
+	if _, ok := earned["first_light"]; !ok {
+		t.Fatalf("expected triumph_earned id first_light in earned set")
+	}
+	if sealCounts["cursebreaker"] != 1 {
+		t.Fatalf("expected cursebreaker count 1, got %d", sealCounts["cursebreaker"])
+	}
+	// Unknown event types must be silently ignored (forward-compat).
+	if len(earned) != 1 {
+		t.Fatalf("expected exactly 1 earned triumph, got %d", len(earned))
+	}
+}
+
+func TestUpdateWeaponLevelsDetectsChange(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "powerlevel-data.json")
+	input := map[string]interface{}{
+		"weapons": map[string]interface{}{
+			"workflow": map[string]interface{}{
+				"level": float64(1),
+			},
+		},
+	}
+	raw, _ := json.Marshal(input)
+	if err := os.WriteFile(path, raw, 0644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	changed, err := updateWeaponLevels(path, map[string]float64{"workflow": 2})
+	if err != nil {
+		t.Fatalf("updateWeaponLevels: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true when weapon level increases")
+	}
+
+	// Re-run with same level — must report no change.
+	changed2, err := updateWeaponLevels(path, map[string]float64{"workflow": 2})
+	if err != nil {
+		t.Fatalf("updateWeaponLevels (no-op): %v", err)
+	}
+	if changed2 {
+		t.Fatalf("expected changed=false when weapon level is unchanged")
+	}
+}

--- a/data/streak.json
+++ b/data/streak.json
@@ -3,5 +3,5 @@
   "longest_streak": 8,
   "last_session_date": "2026-04-08",
   "total_active_days": 15,
-  "computed_at": "2026-04-08T21:20:17Z"
+  "computed_at": "2026-04-09T07:37:03Z"
 }


### PR DESCRIPTION
## Summary

Fixes SO-46: broken cmd/compute test build that was blocking `go test ./...` across the entire powerlevel repo.

## Root cause

The `cmd/compute/main_test.go` file was missing from the repo (untracked). The tests had been written for a planned `level_noted` event emission feature that was never implemented in production code. The test signatures expected:
- `processEvents()` returning 4 values (with a `levelCount int`)  
- `updateWeaponLevels()` returning 3 values (with an events slice)

But the actual implementation returns 3 and 2 values respectively.

## Changes

### `cmd/compute/main_test.go` (new file)
Two tests with correct signatures matching the actual implementation:
- **TestProcessEventsParsesTriggers** — verifies triumph/seal event parsing and forward-compat with unknown event types
- **TestUpdateWeaponLevelsDetectsChange** — verifies level change detection and no-op idempotency

### `cmd/compute/main.go`
Added comment explaining `level_noted` design intent in the `processEvents` switch block:
```go
// level_noted is a planned future event type that would be emitted when a
// weapon level increases (e.g. {"type":"level_noted","skill":"workflow","level":3}).
// It would allow the compute pipeline to log level-up milestones in the event
// stream for audit and renderer use. Not yet implemented — tracked as a future
// enhancement. Unknown event types are intentionally silently ignored here for
// forward-compatibility.
```

## Test results

```
ok  github.com/castrojo/powerlevel/cmd/compute    0.002s
ok  github.com/castrojo/powerlevel/cmd/exporter   0.002s
ok  github.com/castrojo/powerlevel/cmd/streak     0.002s
ok  github.com/castrojo/powerlevel/internal/data  0.002s
ok  github.com/castrojo/powerlevel/internal/renderer  0.002s
```

All 5 packages pass. Closes SO-46.