### PR TITLE
fix(ci): pin Go version using go-version-file: go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
       - run: go test ./... -v
 
   astro:


### PR DESCRIPTION
## Summary

Replace hardcoded `go-version: '1.24'` with `go-version-file: go.mod` in `.github/workflows/ci.yml`.

## Problem

`ci.yml` hardcoded `go-version: 1.24` while `go.mod` declares `go 1.26.1`. This version skew risks silent CI failures if Go 1.25+ language features are introduced.

## Fix

One-line change: replace `go-version: '1.24'` with `go-version-file: go.mod` in the `actions/setup-go` step. This matches the pattern already used in `compute.yml` and `audit.yml`.

## Acceptance Criteria
- ✅ AC#1: `ci.yml` uses `go-version-file: go.mod` instead of hardcoded version
- ✅ AC#2: No other hardcoded Go version strings remain in `ci.yml`
- ✅ AC#3: `go.mod` has a valid `go 1.26.1` directive

Closes SO-47